### PR TITLE
Full class name of Class is incorrect for class which are under defau…

### DIFF
--- a/src/main/java/com/amazon/aws/am2/appmig/glassviewer/constructs/ClassConstruct.java
+++ b/src/main/java/com/amazon/aws/am2/appmig/glassviewer/constructs/ClassConstruct.java
@@ -21,7 +21,7 @@ public class ClassConstruct implements JavaConstruct {
 	private List<String> innerClasses = new ArrayList<>();
 
 	public String getFullClassName() {
-		return packageName == null ? "_default_" : packageName + "." + name;
+		return (packageName == null ? "_default_" : packageName) + "." + name;
 	}
 
 	@Override

--- a/src/main/java/com/amazon/aws/am2/appmig/glassviewer/constructs/InterfaceConstruct.java
+++ b/src/main/java/com/amazon/aws/am2/appmig/glassviewer/constructs/InterfaceConstruct.java
@@ -28,7 +28,7 @@ public class InterfaceConstruct implements JavaConstruct {
 	}
 
 	public String getFullClassName() {
-		return packageName == null ? "_default_" : packageName + "." + name;
+		return (packageName == null ? "_default_" : packageName) + "." + name;
 	}
 
 	@Override


### PR DESCRIPTION
…lt package. Made changes by add parenthesis to append .name

*Issue #, if available:*
Full class name was returning as just _default_ in case if class is under default package
*Description of changes:*
Formatted getClassName method to have . class name appended to package name in both non default and default package case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
