### PR TITLE
fix: not to scan groupId from dependencies in pom.xml

### DIFF
--- a/src/main/java/com/amazon/aws/am2/appmig/utils/Utility.java
+++ b/src/main/java/com/amazon/aws/am2/appmig/utils/Utility.java
@@ -172,7 +172,7 @@ public class Utility {
         String startElement = "";
         String groupId = null;
         try {
-	        while (reader.hasNext()) {
+	        while (reader.hasNext() && groupId == null) {
 	            int event = reader.next();
 	            switch (event) {
 	                case XMLStreamConstants.START_ELEMENT:
@@ -181,7 +181,6 @@ public class Utility {
 	                case XMLStreamConstants.CHARACTERS:
 	                    if (startElement.equals(GROUP_ID)) {
 	                    	groupId = reader.getText().trim();
-	                    	break;
 	                    }
 	                   break;
 	            }


### PR DESCRIPTION
fix: not to scan groupId from dependencies in pom.xml