### PR TITLE
Fix for out of memory issue

### DIFF
--- a/src/main/java/com/amazon/aws/am2/appmig/estimate/DefaultFilter.java
+++ b/src/main/java/com/amazon/aws/am2/appmig/estimate/DefaultFilter.java
@@ -8,6 +8,8 @@ import static com.amazon.aws.am2.appmig.constants.IConstants.EXT_CLASSPATH;
 import static com.amazon.aws.am2.appmig.constants.IConstants.EXT_GIT;
 import static com.amazon.aws.am2.appmig.constants.IConstants.EXT_DS_STORE;
 import static com.amazon.aws.am2.appmig.constants.IConstants.EXT_PROJECT;
+
+import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -54,7 +56,7 @@ public class DefaultFilter implements IFilter {
 
 	private boolean applyFilterOnDir(Path path) {
 		String dirName = path.getFileName().toString();
-		String dirAbsPath = path.getParent()+"/"+dirName;
+		String dirAbsPath = path.getParent()+File.separator+dirName;
 		boolean value1 = Arrays.stream(arrDirFilter).anyMatch(ele -> {
 			return dirName.contentEquals(ele);
 		});


### PR DESCRIPTION
Added clean up steps of Parser after each file to get rid of Out Of Memory issue for large size projects

*Issue #, if available:*

*Description of changes:*
Cleared DFS for after parsing and analyzing each file
Avoided piling up of Prediction context instances by using different cache for each file
Changed / to be replaced with path separator


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
